### PR TITLE
Add pretrained flag to models and CLI

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -19,17 +19,27 @@ if __name__ == "__main__":
     parser.add_argument('--device', type=str, default='cuda' if torch.cuda.is_available() else 'cpu')
     parser.add_argument('--freeze_backbone', dest='freeze_backbone', action='store_true', help='Freeze image backbone (default)')
     parser.add_argument('--unfreeze_backbone', dest='freeze_backbone', action='store_false', help='Load backbone with gradients enabled')
-    parser.set_defaults(freeze_backbone=True)
+    parser.add_argument('--pretrained', dest='pretrained', action='store_true', help='Use pretrained ResNet weights (default)')
+    parser.add_argument('--no_pretrained', dest='pretrained', action='store_false', help='Do not load pretrained weights')
+    parser.set_defaults(freeze_backbone=True, pretrained=True)
     args = parser.parse_args()
 
     # Initialize the model architecture (same parameters as during training)
     if args.model == 'partcrafter':
-        model = PartCrafterModel(max_parts=args.max_parts, tokens_per_part=args.points_per_part, freeze_backbone=args.freeze_backbone)
+        model = PartCrafterModel(max_parts=args.max_parts,
+                                 tokens_per_part=args.points_per_part,
+                                 freeze_backbone=args.freeze_backbone,
+                                 pretrained=args.pretrained)
     elif args.model == 'pointcraft':
-        model = PointCraftPlusPlusModel(max_parts=args.max_parts, tokens_per_part=args.points_per_part, freeze_backbone=args.freeze_backbone)
+        model = PointCraftPlusPlusModel(max_parts=args.max_parts,
+                                        tokens_per_part=args.points_per_part,
+                                        freeze_backbone=args.freeze_backbone,
+                                        pretrained=args.pretrained)
     elif args.model == 'shapeaspoints':
         total_points = args.max_parts * args.points_per_part
-        model = ShapeAsPointsPlusPlusModel(points_per_shape=total_points, freeze_backbone=args.freeze_backbone)
+        model = ShapeAsPointsPlusPlusModel(points_per_shape=total_points,
+                                           freeze_backbone=args.freeze_backbone,
+                                           pretrained=args.pretrained)
 
     model.load_state_dict(torch.load(args.checkpoint, map_location=args.device))
     model = model.to(args.device)

--- a/model.py
+++ b/model.py
@@ -5,7 +5,8 @@ import torchvision.models as models
 
 # PartCrafter architecture
 class PartCrafterModel(nn.Module):
-    def __init__(self, max_parts=8, tokens_per_part=64, d_model=256, n_heads=8, num_blocks=6, freeze_backbone: bool = True):
+    def __init__(self, max_parts=8, tokens_per_part=64, d_model=256, n_heads=8,
+                 num_blocks=6, freeze_backbone: bool = True, pretrained: bool = True):
 
         """
         PartCrafter model: generates part-wise shape tokens with local-global attention.
@@ -98,7 +99,7 @@ class PartCrafterModel(nn.Module):
 
 # Baseline: ShapeAsPoints++
 class ShapeAsPointsPlusPlusModel(nn.Module):
-    def __init__(self, points_per_shape=512, freeze_backbone: bool = True):
+    def __init__(self, points_per_shape=512, freeze_backbone: bool = True, pretrained: bool = True):
         """
         ShapeAsPoints++: generates a whole shape point cloud from image (no part structure).
         - points_per_shape: number of points to output for the whole shape.
@@ -136,7 +137,8 @@ class ShapeAsPointsPlusPlusModel(nn.Module):
 
 # Baseline: PointCRAFT++
 class PointCraftPlusPlusModel(nn.Module):
-    def __init__(self, max_parts=8, tokens_per_part=64, d_model=256, n_heads=8, num_blocks=6, freeze_backbone: bool = True):
+    def __init__(self, max_parts=8, tokens_per_part=64, d_model=256, n_heads=8,
+                 num_blocks=6, freeze_backbone: bool = True, pretrained: bool = True):
         """
         PointCRAFT++: generates each part independently (no global part-part attention).
         - Similar parameters as PartCrafterModel, but uses only local attention blocks.

--- a/training.py
+++ b/training.py
@@ -37,7 +37,9 @@ if __name__ == "__main__":
     parser.add_argument('--device', type=str, default='cuda' if torch.cuda.is_available() else 'cpu', help="Device: 'cuda' or 'cpu'")
     parser.add_argument('--freeze_backbone', dest='freeze_backbone', action='store_true', help='Freeze image backbone (default)')
     parser.add_argument('--unfreeze_backbone', dest='freeze_backbone', action='store_false', help='Train backbone weights')
-    parser.set_defaults(freeze_backbone=True)
+    parser.add_argument('--pretrained', dest='pretrained', action='store_true', help='Use pretrained ResNet weights (default)')
+    parser.add_argument('--no_pretrained', dest='pretrained', action='store_false', help='Do not load pretrained weights')
+    parser.set_defaults(freeze_backbone=True, pretrained=True)
     args = parser.parse_args()
 
     # Load dataset and split into train/validation
@@ -55,12 +57,20 @@ if __name__ == "__main__":
                             shuffle=False, drop_last=False)
     # Instantiate model
     if args.model == 'partcrafter':
-        model = PartCrafterModel(max_parts=args.max_parts, tokens_per_part=args.points_per_part, freeze_backbone=args.freeze_backbone)
+        model = PartCrafterModel(max_parts=args.max_parts,
+                                 tokens_per_part=args.points_per_part,
+                                 freeze_backbone=args.freeze_backbone,
+                                 pretrained=args.pretrained)
     elif args.model == 'pointcraft':
-        model = PointCraftPlusPlusModel(max_parts=args.max_parts, tokens_per_part=args.points_per_part, freeze_backbone=args.freeze_backbone)
+        model = PointCraftPlusPlusModel(max_parts=args.max_parts,
+                                        tokens_per_part=args.points_per_part,
+                                        freeze_backbone=args.freeze_backbone,
+                                        pretrained=args.pretrained)
     elif args.model == 'shapeaspoints':
         total_points = args.max_parts * args.points_per_part  # points_per_shape used in dataset
-        model = ShapeAsPointsPlusPlusModel(points_per_shape=total_points, freeze_backbone=args.freeze_backbone)
+        model = ShapeAsPointsPlusPlusModel(points_per_shape=total_points,
+                                           freeze_backbone=args.freeze_backbone,
+                                           pretrained=args.pretrained)
     model = model.to(args.device)
     optimizer = optim.Adam(filter(lambda p: p.requires_grad, model.parameters()), lr=args.lr)
 


### PR DESCRIPTION
## Summary
- add `pretrained` argument for all model classes
- expose pretrained switch via CLI in `generate.py` and `training.py`

## Testing
- `python -m py_compile model.py generate.py training.py dataloader.py toy_dataset_test.py`
- `python generate.py --help`
- `python training.py --help` *(after installing torch and trimesh)*
