### PR TITLE
Удалена лишняя проверка в цикле обучения

### DIFF
--- a/training.py
+++ b/training.py
@@ -290,8 +290,6 @@ if __name__ == "__main__":
         model.train()
         if args.save_every > 0 and epoch % args.save_every == 0:
             ckpt_path = f"{args.model}_epoch{epoch}.pth"
-        if args.save_every > 0 and epoch % args.save_every == 0:
-            ckpt_path = f"{args.model}_epoch{epoch}.pth"
             save_checkpoint(model, optimizer, scheduler, epoch, ckpt_path)
             logger.info(f"Сохранён чекпоинт: {ckpt_path}")
 


### PR DESCRIPTION
## Summary
- убрана лишняя строка вычисления `ckpt_path` в цикле сохранения чекпоинтов
- файл теперь сохраняется один раз за эпоху

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873d5cea7ac8332b61b8bfbb3a5a92a